### PR TITLE
Rename artifact to match project name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.tomcat</groupId>
-    <artifactId>vault-tomcat</artifactId>
+    <artifactId>tomcat-vault</artifactId>
     <version>1.0.8.Final</version>
     <name>Tomcat Vault extension</name>
     <dependencies>


### PR DESCRIPTION
@S4n60w3n pointed out in https://issues.jboss.org/browse/JWS-587 that the artifacts generated by the build are all named 'vault-tomcat' instead of 'tomcat-vault'. Shouldn't the artifact name match the project name? If so, here's a PR to correct it :)

I couldn't find the artifacts anywhere in maven central, so I don't think the change will break anything.