### PR TITLE
Check catalina.base before catalina.home like tomcat does

### DIFF
--- a/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
+++ b/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
@@ -3,6 +3,7 @@ package org.apache.tomcat.vault.util;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.io.File;
 
 import org.apache.tomcat.util.IntrospectionUtils.PropertySource;
 import org.apache.tomcat.vault.security.vault.SecurityVault;
@@ -23,16 +24,27 @@ public class PropertySourceVault implements PropertySource {
     private Properties properties;
 
     public PropertySourceVault() {
-        vault = null;
-        properties = null;
+        this.vault = null;
+        this.properties = null;
+
         String catalinaHome = System.getProperty("catalina.home");
-        if (catalinaHome == null)
-           catalinaHome = System.getProperty("catalina.base");
-        if (catalinaHome == null) {
-           // Here probably need to guess the location...
-           catalinaHome = ".";
+        String catalinaBase = System.getProperty("catalina.base");
+        String catalina = null;
+
+        if (new File(catalinaBase + PROPERTY_FILE_RELATIVE_PATH).exists()) {
+            catalina = catalinaBase;
+            log.debug("vault.properties found in catalina.base [" + catalina + "]");
+        } else if (new File(catalinaHome + PROPERTY_FILE_RELATIVE_PATH).exists()) {
+            // Using catalina.home is kept for backwards compat
+            catalina = catalinaHome;
+            log.debug("vault.properties found in catalina.home [" + catalina + "]");
+        } else {
+            // Always default to catalina.base if it doesn't exist in either place
+            catalina = catalinaBase;
+            log.debug("vault.properties not found, using catalina.base [" + catalina + "]");
         }
-        pfm = new PropertyFileManager(catalinaHome + PROPERTY_FILE_RELATIVE_PATH);
+
+        this.pfm = new PropertyFileManager(catalina + PROPERTY_FILE_RELATIVE_PATH);
 
         this.init();
     }


### PR DESCRIPTION
Tomcat checks catalina.base for all of it's config files, so I updated vault to do the same. If it doesn't find the file in catalina.base, it checks catalina.home for backwards compat. Also note that it defaults to catalina.base if neither is found so that the warning message clues the user in on where to put the file.