### PR TITLE
A workaround so that the init doesn't log another exception after it …

### DIFF
--- a/src/main/java/org/apache/tomcat/vault/util/PropertyFileManager.java
+++ b/src/main/java/org/apache/tomcat/vault/util/PropertyFileManager.java
@@ -48,6 +48,7 @@ public class PropertyFileManager {
             prop.load(input);
         } catch (IOException ex) {
             log.error(ex.getMessage(), ex);
+            return null;
         } finally {
             if (input != null) {
                 try {

--- a/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
+++ b/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
@@ -56,6 +56,11 @@ public class PropertySourceVault implements PropertySource {
             // Load vault property file
             properties = pfm.load();
 
+            // If properties is null then there was an exception
+            if (properties == null) {
+                return;
+            }
+
             Map<String, Object> options = new HashMap<String, Object>();
             options.put(PicketBoxSecurityVault.KEYSTORE_URL, properties.getProperty("KEYSTORE_URL"));
             options.put(PicketBoxSecurityVault.KEYSTORE_PASSWORD, properties.getProperty("KEYSTORE_PASSWORD"));
@@ -73,6 +78,11 @@ public class PropertySourceVault implements PropertySource {
     @Override
     public String getProperty(String arg0) {
         String result = null;
+
+        // If the vault failed to init, then return without change
+        if (!vault.isInitialized()) {
+            return arg0;
+        }
 
         if (arg0.startsWith("VAULT::")) {
             String vaultdata[] = arg0.split("::");


### PR DESCRIPTION
…can't find vault.properties

The issue I'm attempting to address is that when you us the PropertySourceVault but fail to create conf/vault.properties two exceptions are thrown, one for the FNFE and one for the KEYSTORE_URL being null which will ALWAYS occur if the vault.properties file isn't found. This could cause some confusion for users, so we should only log the first exception.

```
28-Jul-2017 09:17:40.870 SEVERE [main] org.apache.tomcat.vault.util.PropertyFileManager.load /opt/rh/jws4/root/usr/share/tomcat/conf/vault.properties (No such file or directory)
 java.io.FileNotFoundException: /opt/rh/jws4/root/usr/share/tomcat/conf/vault.properties (No such file or directory)
        at java.io.FileInputStream.open(Native Method)
....
28-Jul-2017 09:17:40.872 SEVERE [main] org.apache.tomcat.vault.util.PropertySourceVault.init Option [KEYSTORE_URL] is null or empty
 org.apache.tomcat.vault.security.vault.SecurityVaultException: Option [KEYSTORE_URL] is null or empty
```