### PR TITLE
Add a system property that allows vault.properties to be loaded from …

### DIFF
--- a/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
+++ b/src/main/java/org/apache/tomcat/vault/util/PropertySourceVault.java
@@ -44,7 +44,13 @@ public class PropertySourceVault implements PropertySource {
             log.debug("vault.properties not found, using catalina.base [" + catalina + "]");
         }
 
-        this.pfm = new PropertyFileManager(catalina + PROPERTY_FILE_RELATIVE_PATH);
+        String vaultPropertiesPath = catalina + PROPERTY_FILE_RELATIVE_PATH;
+        String vaultProperties = System.getProperty("org.apache.tomcat.vault.util.VAULT_PROPERTIES");
+        if (vaultProperties != null) {
+            vaultPropertiesPath = vaultProperties;
+        }
+
+        this.pfm = new PropertyFileManager(vaultPropertiesPath);
 
         this.init();
     }


### PR DESCRIPTION
…anywhere on the filesystem, not limited to CATALINA_BASE or CATALINA_HOME.