### PR TITLE
Replace 'null input buffer' message from Cipher.doFinal() with more i…

### DIFF
--- a/src/main/java/org/apache/tomcat/vault/security/vault/PicketBoxSecurityVault.java
+++ b/src/main/java/org/apache/tomcat/vault/security/vault/PicketBoxSecurityVault.java
@@ -268,6 +268,11 @@ public class PicketBoxSecurityVault implements SecurityVault {
 
         byte[] encryptedValue = vaultContent.getVaultData(alias, vaultBlock, attributeName);
 
+        if (encryptedValue == null) {
+            throw new SecurityVaultException(sm.getString("picketBoxSecurityVault.attributeNotInVault", alias,
+                vaultBlock, attributeName));
+        }
+
         SecretKeySpec secretKeySpec = new SecretKeySpec(adminKey.getEncoded(), encryptionAlgorithm);
         EncryptionUtil encUtil = new EncryptionUtil(encryptionAlgorithm, keySize);
         try {

--- a/src/main/resources/org/apache/tomcat/vault/security/vault/LocalStrings.properties
+++ b/src/main/resources/org/apache/tomcat/vault/security/vault/LocalStrings.properties
@@ -19,6 +19,7 @@ picketBoxSecurityVault.ambiguosKeyForSecurityVaultTransformation=Ambiguous vault
 picketBoxSecurityVault.cannotDeleteOriginalVaultFile=Cannot delete original Security Vault file ([{0}]). Delete the file manually before next start, please.
 picketBoxSecurityVault.keyStoreConvertedToJCEKS=Security Vault key store successfuly converted to JCEKS type ([{0}]). From now on use JCEKS as KEYSTORE_TYPE in Security Vault configuration.
 picketBoxSecurityVault.vaultDoesNotContainSecretKey=Security Vault does not contain SecretKey entry under alias ([{0}])
+picketBoxSecurityVault.attributeNotInVault=Data not found in alias ({0}) for VAULT::{1}::{2}::
 
 securityVaultFactory.attemptToCreateSecondVault=Attempt to create the second Security Vault [[{0}]] is invalid. Only one Security Vault is supported. Change your configuration, please.
 


### PR DESCRIPTION
…nformative message by catching empty vault data before passing to Cipher, logging it, and throwing an exception.

With this commit we see the following:

```
SEVERE: Data not found in alias (my_vault) for VAULT::my_block::manager_password1::
org.apache.tomcat.vault.security.vault.SecurityVaultException: Data not found in alias (my_vault) for VAULT::my_block::manager_password1::
	at org.apache.tomcat.vault.security.vault.PicketBoxSecurityVault.retrieve(PicketBoxSecurityVault.java:272)
....
```

instead of:

```
SEVERE [main] org.apache.tomcat.vault.util.PropertySourceVault.getProperty java.lang.IllegalArgumentException: Null input buffer
--
org.apache.tomcat.vault.security.vault.SecurityVaultException: java.lang.IllegalArgumentException: Null input buffer
at org.apache.tomcat.vault.security.vault.PicketBoxSecurityVault.retrieve(PicketBoxSecurityVault.java:299)
....
```